### PR TITLE
fix(system): 从UserCreateDTO和UserUpdateDTO中移除password字段

### DIFF
--- a/gox-modules/gox-system/src/main/dto/com/zhengchalei/gox/modules/system/entity/User.dto
+++ b/gox-modules/gox-system/src/main/dto/com/zhengchalei/gox/modules/system/entity/User.dto
@@ -26,11 +26,13 @@ UserDetailDTO {
 
 input UserCreateDTO {
     #allScalars(this)
+    -password
 }
 
 input UserUpdateDTO {
     #allScalars(this)
     id!
+    -password
 }
 
 input UserRoleUpdateDTO {


### PR DESCRIPTION
移除用户创建和更新DTO中的password字段，避免密码通过DTO直接暴露和修改